### PR TITLE
When testing the script in a CICD workflow, don't run the playbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,10 @@ jobs:
           path: ansible-mac-security
 
       - name: Test Installer Script
-        run: ./install.sh -t
+        run: ./install.sh -t  
+        
+      - name: Test Playbook
+        run: ansible-playbook main.yml --skip-tags "homebrew"   
         env:
           ANSIBLE_FORCE_COLOR: '1'
 

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,8 @@ should_configure_ansible() {
 run_playbook() {
   if $CICD_TEST
   then
-    ansible-playbook main.yml -i inventory --extra-vars '{\"configure_sudoers\":\"false\"}' --skip-tags "homebrew" -vv
+    echo "Playbook would have run here."
+    exit 0
   else
     ansible-playbook main.yml -i inventory --extra-vars '{\"configure_sudoers\":\"false\"}' 
   fi
@@ -94,8 +95,6 @@ system_setup() {
     echo "Running playbook" && \
     run_playbook && \
     echo "Playbook completed"
-    
-  exit 0
 }
 
 if [ $# -ge 1 ] && [ $1 == "-t" ]


### PR DESCRIPTION
This resolves an error whereby the script runs the "main" branch of the playbook and does not actually test changes to the checked out branch

FIxes #10 